### PR TITLE
Documentation fixes around policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,18 @@ The following policy statement must also be assigned to the IAM role, so that th
 
 ``` json
     {
-        "Sid": "allow-kms-decrypt",
-        "Effect": "Allow",
-        "Action": [
-            "kms:Decrypt"
-        ],
-        "Resource": [
-            "*"
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowKMSDecrypt",
+                "Effect": "Allow",
+                "Action": [
+                    "kms:Decrypt"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            }
         ]
     }
 ```
@@ -73,13 +78,18 @@ The IAM role assigned to the Lambda function must contain the following policy s
 
 ``` json
     {
-        "Sid": "allow-get-function-config",
-        "Effect": "Allow",
-        "Action": [
-            "lambda:GetFunctionConfiguration"
-        ],
-        "Resource": [
-            "*"
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowGetFunctionConfig",
+                "Effect": "Allow",
+                "Action": [
+                    "lambda:GetFunctionConfiguration"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            }
         ]
     }
 ```
@@ -87,7 +97,7 @@ The IAM role assigned to the Lambda function must contain the following policy s
 #### Configure the Client
 
 ``` java
-    final String invokedFunctionArn = context.getInvokedFunctionArn()
+    final String invokedFunctionArn = context.getInvokedFunctionArn();
     final VaultClient vaultClient = DefaultCerberusClientFactory.getClientForLambda(invokedFunctionArn);
 ```
 


### PR DESCRIPTION
Policy JSON as written generates two different errors in the AWS UI. Version/statement additions fix one error, removing '-' from Sid fixes the other.  Also, missing a semi-colon... docs that compile > than those that don't