### PR TITLE
removing all but AWS SDK and its transitive dependencies from shadow jar

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 def AWS_SDK_VERSION = '1.11.75'
+def VAULT_CLIENT_COORDINATES = "com.nike:vault-client:1.2.1"
 //noinspection GroovyAssignabilityCheck
 dependencies {
 
@@ -31,10 +32,13 @@ dependencies {
  * We do this because AWS constantly breaks backwards compatibility of their SDK with minor version releases.          *
  * We do not want to dictate what SDK version users of Cerberus should use.                                            *
  ***********************************************************************************************************************/
-    compile "com.nike:vault-client:1.2.1"
-    compile "joda-time:joda-time:2.8.1"
-    compile "org.apache.commons:commons-lang3:3.4"
-    compile "org.slf4j:slf4j-api:1.7.14"
+
+    // these will be added to the POM and excluded from the shadow jar
+    shadow VAULT_CLIENT_COORDINATES
+    compile VAULT_CLIENT_COORDINATES
+    shadow "joda-time:joda-time:2.8.1"
+    shadow "org.apache.commons:commons-lang3:3.4"
+    shadow "org.slf4j:slf4j-api:1.7.14"
 
     compile "com.amazonaws:aws-java-sdk-core:${AWS_SDK_VERSION}"
     compile "com.amazonaws:aws-java-sdk-kms:${AWS_SDK_VERSION}"
@@ -56,6 +60,12 @@ dependencies {
 
 shadowJar {
     classifier = ''
+    dependencies {
+      // exclude these from the fat jar
+      project.configurations.shadow.each {
+        exclude it.name
+      }
+    }
     relocate('com.', 'cerberus.com.') {
         exclude 'com.nike.**'
     }


### PR DESCRIPTION
Move joda-time, slf4j-api, vault-client, and commons-lang3 dependencies to "shadow" configuration such that they are excluded from the contents of the shadow jar and, instead, added to the POM. All that remains in the shadow jar is the AWS SDK and its transitive dependencies.