### PR TITLE
fix erroneous package relocation for non-shadowed dependencies

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -61,21 +61,21 @@ dependencies {
 shadowJar {
     classifier = ''
     dependencies {
-      // exclude these from the fat jar
+      // exclude these from the shadow jar
       project.configurations.shadow.each {
         exclude it.name
       }
     }
     relocate('com.', 'cerberus.com.') {
         exclude 'com.nike.**'
+        exclude 'com.google.**'
     }
     relocate('org.', 'cerberus.org.') {
         exclude 'org.slf4j.**'
+        exclude 'org.joda.**'
+        exclude 'org.apache.commons.lang3.**'
     }
-    relocate 'javax.annotation', 'cerberus.javax.annotation'
     relocate 'models.', 'cerberus.models.'
     relocate 'mozilla.', 'cerberus.mozilla.'
-    relocate 'okhttp3.', 'cerberus.okhttp3.'
-    relocate 'okio.', 'cerberus.okio.'
     relocate 'software.', 'cerberus.software.'
 }


### PR DESCRIPTION
fix erroneous package relocation for dependencies now included in the POM, as well as their transitive dependencies - this impacted references to the following packages after commit e7c0492b0848e47b225ad7ac7426625782b01d2f (each were wrongly prefixed with “cerberus.”), despite exclusion of these dependencies from the shadow jar:

com.google.code.gson
okhttp3
org.joda.time
org.apache.commons.lang3
javax.annotation