### PR TITLE
Fix authentication for IAM role paths

### DIFF
--- a/src/main/java/com/nike/cerberus/client/auth/DefaultCerberusCredentialsProviderChain.java
+++ b/src/main/java/com/nike/cerberus/client/auth/DefaultCerberusCredentialsProviderChain.java
@@ -17,6 +17,7 @@
 package com.nike.cerberus.client.auth;
 
 import com.nike.cerberus.client.DefaultCerberusUrlResolver;
+import com.nike.cerberus.client.auth.aws.InstanceProfileArnVaultCredentialsProvider;
 import com.nike.cerberus.client.auth.aws.InstanceProfileVaultCredentialsProvider;
 import com.nike.cerberus.client.auth.aws.InstanceRoleVaultCredentialsProvider;
 import com.nike.vault.client.UrlResolver;
@@ -53,6 +54,7 @@ public class DefaultCerberusCredentialsProviderChain extends VaultCredentialsPro
         super(new EnvironmentCerberusCredentialsProvider(),
                 new SystemPropertyCerberusCredentialsProvider(),
                 new InstanceProfileVaultCredentialsProvider(urlResolver),
+                new InstanceProfileArnVaultCredentialsProvider(urlResolver),
                 new InstanceRoleVaultCredentialsProvider(urlResolver));
     }
 }

--- a/src/main/java/com/nike/cerberus/client/auth/aws/InstanceProfileArnVaultCredentialsProvider.java
+++ b/src/main/java/com/nike/cerberus/client/auth/aws/InstanceProfileArnVaultCredentialsProvider.java
@@ -1,0 +1,43 @@
+package com.nike.cerberus.client.auth.aws;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.util.EC2MetadataUtils;
+import com.nike.vault.client.UrlResolver;
+import com.nike.vault.client.VaultClientException;
+
+/**
+ * This Credentials provider will look up the assigned InstanceProfileArn for this machine and attempt
+ * To automatically retrieve a Vault token from CMS's iam-auth endpoint that takes region, acct id, role name.
+ */
+public class InstanceProfileArnVaultCredentialsProvider extends BaseAwsCredentialsProvider {
+
+    /**
+     * Constructor to setup credentials provider using the specified
+     * implementation of {@link UrlResolver}
+     *
+     * @param urlResolver Resolver for resolving the Cerberus URL
+     */
+    public InstanceProfileArnVaultCredentialsProvider(UrlResolver urlResolver) {
+        super(urlResolver);
+    }
+
+    @Override
+    protected void authenticate() {
+        EC2MetadataUtils.IAMInfo iamInfo = getIamInfo();
+        String instanceProfileArn = iamInfo.instanceProfileArn;
+        Region region = Regions.getCurrentRegion();
+
+        try {
+            getAndSetToken(instanceProfileArn, region);
+        } catch (Exception e) {
+            throw new VaultClientException(String.format("Failed to authenticate with Cerberus's iam auth endpoint " +
+                            "using the following auth info, iamPrincipalArn: %s, region: %s",
+                    instanceProfileArn, region), e);
+        }
+    }
+
+    protected EC2MetadataUtils.IAMInfo getIamInfo() {
+        return EC2MetadataUtils.getIAMInstanceProfileInfo();
+    }
+}


### PR DESCRIPTION
Currently, IAM roles with paths (e.g. 'arn:iam:aws:instance-profile/role/name/path/structure') cannot authenticate with Cerberus.