### PR TITLE
Additionally constructing role without path.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version=4.1.1_RC1
+version=4.2.0
 groupId=com.nike
 artifactId=cerberus-client

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version=4.0.4
+version=4.0.5RC1
 groupId=com.nike
 artifactId=cerberus-client

--- a/src/main/java/com/nike/cerberus/client/auth/aws/InstanceRoleVaultCredentialsProvider.java
+++ b/src/main/java/com/nike/cerberus/client/auth/aws/InstanceRoleVaultCredentialsProvider.java
@@ -152,6 +152,10 @@ public class InstanceRoleVaultCredentialsProvider extends BaseAwsCredentialsProv
         final String accountId = instanceProfileInfo.accountId;
         final String path = parsePathFromInstanceProfileName(instanceProfileInfo.profileName);
 
+        // There isn't a 100% reliable method for constructing the role ARN from the meta-data endpoint.
+        // So here we try both with and without the path that was used in the instanceProfileArn.
+        // The only reason we don't try and auth with the instanceProfileArn is it isn't a valid ARN type
+        // that can be included in a KMS key policy.
         for (String roleName : securityCredentialsKeySet) {
             result.add(buildRoleArn(accountId, path, roleName));
             if (path != null) {

--- a/src/main/java/com/nike/cerberus/client/auth/aws/InstanceRoleVaultCredentialsProvider.java
+++ b/src/main/java/com/nike/cerberus/client/auth/aws/InstanceRoleVaultCredentialsProvider.java
@@ -42,7 +42,7 @@ import static com.nike.cerberus.client.auth.aws.StaticIamRoleVaultCredentialsPro
  * response using KMS. If the assigned role has been granted the appropriate
  * provisioned for usage of Vault, it will succeed and have a token that can be
  * used to interact with Vault.
- *
+ * <p>
  * This class uses the AWS Instance Metadata endpoint to look-up information automatically.
  *
  * @see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">AWS Instance Metadata</a>
@@ -157,11 +157,12 @@ public class InstanceRoleVaultCredentialsProvider extends BaseAwsCredentialsProv
         // The only reason we don't try and auth with the instanceProfileArn is it isn't a valid ARN type
         // that can be included in a KMS key policy.
         for (String roleName : securityCredentialsKeySet) {
-            result.add(buildRoleArn(accountId, path, roleName));
             if (path != null) {
-                // sometimes the path isn't needed
-                result.add(buildRoleArn(accountId, null, roleName));
+                // if path was supplied in instanceProfileArn, we'll try using it first
+                // there is no guarantee that the path used in the instanceProfileArn was also used in the roleArn but it is a common pattern
+                result.add(buildRoleArn(accountId, path, roleName));
             }
+            result.add(buildRoleArn(accountId, null, roleName));
         }
 
         return result;
@@ -192,7 +193,7 @@ public class InstanceRoleVaultCredentialsProvider extends BaseAwsCredentialsProv
 
     /**
      * Parse the path out of a instanceProfileName or return null for no path
-     *
+     * <p>
      * e.g. parse "foo/bar" out of "foo/bar/name"
      */
     protected static String parsePathFromInstanceProfileName(String instanceProfileName) {
@@ -212,7 +213,7 @@ public class InstanceRoleVaultCredentialsProvider extends BaseAwsCredentialsProv
 
     /**
      * If a path is supplied, prepend it to the role name.
-     *
+     * <p>
      * e.g. roleWithPath(null, "foo") returns "foo".
      * e.g. roleWithPath("bar", "foo") returns "bar/foo".
      * e.g. roleWithPath("bar/more", "foo") returns "bar/more/foo".
@@ -229,9 +230,13 @@ public class InstanceRoleVaultCredentialsProvider extends BaseAwsCredentialsProv
      * Bean for holding Instance Profile parse results
      */
     protected static class InstanceProfileInfo {
-        /** AWS Account ID */
+        /**
+         * AWS Account ID
+         */
         String accountId;
-        /** Name found after "instance-profile/" in the instance profile ARN, includes paths e.g. "foo/bar/name" */
+        /**
+         * Name found after "instance-profile/" in the instance profile ARN, includes paths e.g. "foo/bar/name"
+         */
         String profileName;
     }
 }

--- a/src/main/java/com/nike/cerberus/client/auth/aws/InstanceRoleVaultCredentialsProvider.java
+++ b/src/main/java/com/nike/cerberus/client/auth/aws/InstanceRoleVaultCredentialsProvider.java
@@ -154,6 +154,10 @@ public class InstanceRoleVaultCredentialsProvider extends BaseAwsCredentialsProv
 
         for (String roleName : securityCredentialsKeySet) {
             result.add(buildRoleArn(accountId, path, roleName));
+            if (path != null) {
+                // sometimes the path isn't needed
+                result.add(buildRoleArn(accountId, null, roleName));
+            }
         }
 
         return result;

--- a/src/test/java/com/nike/cerberus/client/auth/aws/InstanceRoleVaultCredentialsProviderTest.java
+++ b/src/test/java/com/nike/cerberus/client/auth/aws/InstanceRoleVaultCredentialsProviderTest.java
@@ -38,6 +38,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -155,10 +156,10 @@ public class InstanceRoleVaultCredentialsProviderTest extends BaseCredentialsPro
         Set<String> roles = Sets.newSet("brewmaster-foo-cerberus");
 
         Set<String> results = buildIamRoleArns(instanceProfileArn, roles);
-        assertEquals(1, results.size());
-        String result = results.iterator().next();
-
-        assertEquals("arn:aws:iam::1234567890123:role/brewmaster/foo/brewmaster-foo-cerberus", result);
+        assertEquals(2, results.size());
+        Iterator<String> iterator = results.iterator();
+        assertEquals("arn:aws:iam::1234567890123:role/brewmaster/foo/brewmaster-foo-cerberus", iterator.next());
+        assertEquals("arn:aws:iam::1234567890123:role/brewmaster-foo-cerberus", iterator.next());
     }
 
     @Test
@@ -179,10 +180,7 @@ public class InstanceRoleVaultCredentialsProviderTest extends BaseCredentialsPro
         Set<String> roles = Sets.newSet("foo-cerberus-SDFLKJRWE234");
 
         Set<String> results = buildIamRoleArns(instanceProfileArn, roles);
-        assertEquals(1, results.size());
-        String result = results.iterator().next();
-
-        assertEquals("arn:aws:iam::1234567890123:role/brewmaster/foo/foo-cerberus-SDFLKJRWE234", result);
+        assertEquals(2, results.size());
     }
 
     @Test


### PR DESCRIPTION
It seems that this case is sometimes also needed. There isn't a 100% reliable method for constructing the role ARN from the meta-data endpoint.  So we need to try both with and without the path that was used in the instanceProfileArn.  

Alternatively, with additional IAM permissions we could look up the role by calling AWS APIs (possible future improvement).  