### PR TITLE
Excluding org.w3c.dom and org.xml from relocation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version=7.1.1
+version=7.1.2
 groupId=com.nike
 artifactId=cerberus-client

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -82,6 +82,8 @@ shadowJar {
         exclude 'org.slf4j.**'
         exclude 'org.joda.**'
         exclude 'org.apache.commons.lang3.**'
+        exclude 'org.w3c.dom.**'
+        exclude 'org.xml.**'
     }
     relocate 'models.', 'cerberus.models.'
     relocate 'mozilla.', 'cerberus.mozilla.'


### PR DESCRIPTION
Excluding org.w3c.dom and org.xml from relocation because they are part of the Java platform.

This wasn't impacting most Cerberus client usage but it was impacting one Nike-internal project.